### PR TITLE
Implement ruleURL technique support

### DIFF
--- a/layers/spec/v4.5/layerformat.md
+++ b/layers/spec/v4.5/layerformat.md
@@ -54,6 +54,7 @@ Technique objects are used to store both techniques and subtechniques. The only 
 | color | String | No | "" | Explicit color value assigned to the technique in this layer. Note that explicitly defined color overrides any color implied by the score - the Navigator will display the technique using the explicitly defined color |
 | metadata | Array of Metadata objects and Divider objects | No | | User defined metadata for this technique. See definitions of Metadata objects and Divider objects below |
 | links | Array of Link objects and Divider objects | No | | User assigned links for this technique. See definitions of Link objects and Divider objects below |
+| ruleURL | String | No | n/a | URL linking to rule details for the technique. Opens in a new browser tab when selected |
 | showSubtechniques | boolean | No | false | if true, the sub-techniques under this technique will be shown by default. This field is only valid under a technique with subtechniques. Note that subtechniques can still be shown/hidden using the UI controls - this field is simply the default state. |
 
 ## Gradient Object properties
@@ -137,6 +138,7 @@ The following example illustrates the layer file format of a single layer:
             "score": 0,
             "color": "#fd8d3c",
             "comment": "This is a comment for technique T1110",
+            "ruleURL": "https://example.com/rules/T1110",
             "showSubtechniques": true
         },
         {
@@ -148,7 +150,8 @@ The following example illustrates the layer file format of a single layer:
                     "label": "Navigator GitHub",
                     "url": "https://github.com/mitre-attack/attack-navigator"
                 }
-            ]
+            ],
+            "ruleURL": "https://example.com/rules/T1110.001"
         },
         {
             "techniqueID": "T1134",
@@ -260,6 +263,7 @@ The following example illustrates the layer file format of multiple layers. The 
                 "score": 0,
                 "color": "#fd8d3c",
                 "comment": "This is a comment for technique T1110",
+                "ruleURL": "https://example.com/rules/T1110",
                 "showSubtechniques": true
             },
             {
@@ -271,7 +275,8 @@ The following example illustrates the layer file format of multiple layers. The 
                         "label": "Navigator GitHub",
                         "url": "https://github.com/mitre-attack/attack-navigator"
                     }
-                ]
+                ],
+                "ruleURL": "https://example.com/rules/T1110.001"
             },
             {
                 "techniqueID": "T1134",

--- a/nav-app/src/app/classes/link.ts
+++ b/nav-app/src/app/classes/link.ts
@@ -1,6 +1,8 @@
 export class Link {
     public label: string;
     public url: string;
+    /** optional rule URL to open in new tab */
+    public ruleURL?: string;
     public divider: boolean;
 
     constructor() {
@@ -8,7 +10,12 @@ export class Link {
     }
 
     public serialize(): object {
-        return this.label && this.url ? { label: this.label, url: this.url } : { divider: this.divider };
+        if (this.label && this.url) {
+            let obj: any = { label: this.label, url: this.url };
+            if (this.ruleURL) obj.ruleURL = this.ruleURL;
+            return obj;
+        }
+        return { divider: this.divider };
     }
 
     public deserialize(rep: any): void {
@@ -22,6 +29,11 @@ export class Link {
                 if (typeof obj.label === 'string') this.label = obj.label;
                 else console.error("TypeError: Link field 'label' is not a string");
             } else console.error("Error: Link required field 'label' not present");
+
+            if ('ruleURL' in obj) {
+                if (typeof obj.ruleURL === 'string') this.ruleURL = obj.ruleURL;
+                else console.error("TypeError: Link field 'ruleURL' is not a string");
+            }
         } else if ('divider' in obj) {
             // divider object
             if (typeof obj.divider === 'boolean') this.divider = obj.divider;

--- a/nav-app/src/app/classes/technique-vm.ts
+++ b/nav-app/src/app/classes/technique-vm.ts
@@ -15,6 +15,7 @@ export class TechniqueVM {
     public color: string = ''; // manually assigned color-class name
     public enabled: boolean = true;
     public comment: string = '';
+    public ruleURL: string = '';
 
     public metadata: Metadata[] = [];
     public get metadataStr(): string {
@@ -49,7 +50,15 @@ export class TechniqueVM {
      * @return true if it has annotations, false otherwise
      */
     public annotated(): boolean {
-        return this.score != '' || this.color != '' || !this.enabled || this.comment != '' || this.links.length !== 0 || this.metadata.length !== 0;
+        return (
+            this.score != '' ||
+            this.color != '' ||
+            !this.enabled ||
+            this.comment != '' ||
+            this.ruleURL != '' ||
+            this.links.length !== 0 ||
+            this.metadata.length !== 0
+        );
     }
 
     /**
@@ -63,6 +72,7 @@ export class TechniqueVM {
         this.aggregateScore = '';
         this.aggregateScoreColor = '';
         this.links = [];
+        this.ruleURL = '';
         this.metadata = [];
     }
 
@@ -84,6 +94,7 @@ export class TechniqueVM {
         if (this.score !== '' && !isNaN(Number(this.score))) rep.score = Number(this.score);
         rep.color = this.color;
         rep.comment = this.comment;
+        if (this.ruleURL) rep.ruleURL = this.ruleURL;
         rep.enabled = this.enabled;
         rep.metadata = this.metadata.filter((m) => m.valid()).map((m) => m.serialize());
         rep.links = this.links.filter((l) => l.valid()).map((l) => l.serialize());
@@ -116,6 +127,10 @@ export class TechniqueVM {
         if ('score' in obj) {
             if (typeof obj.score === 'number') this.score = String(obj.score);
             else console.error('TypeError: technique score field is not a number:', obj.score, '(', typeof obj.score, ')');
+        }
+        if ('ruleURL' in obj) {
+            if (typeof obj.ruleURL === 'string') this.ruleURL = obj.ruleURL;
+            else console.error('TypeError: technique ruleURL field is not a string:', obj.ruleURL, '(', typeof obj.ruleURL, ')');
         }
         if ('enabled' in obj) {
             if (typeof obj.enabled === 'boolean') this.enabled = obj.enabled;

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -74,6 +74,7 @@ export abstract class Cell {
             (this.tactic && this.viewModel.getTechniqueVM(this.technique, this.tactic).comment.length > 0) ||
             this.viewModel.getTechniqueVM(this.technique, this.tactic).metadata.length > 0 ||
             this.viewModel.getTechniqueVM(this.technique, this.tactic).links.length > 0 ||
+            this.viewModel.getTechniqueVM(this.technique, this.tactic).ruleURL ||
             this.hasNotes()
         )
             theclass += ' underlined';
@@ -150,6 +151,9 @@ export abstract class Cell {
                 if (this.configService.getFeature('metadata_underline')) return this.configService.metadataColor;
             }
             if (tvm.links.length > 0) {
+                if (this.configService.getFeature('link_underline')) return this.configService.linkColor;
+            }
+            if (tvm.ruleURL) {
                 if (this.configService.getFeature('link_underline')) return this.configService.linkColor;
             }
         }

--- a/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.html
+++ b/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.html
@@ -30,6 +30,7 @@
         <div class="contextMenu-section">
             <div class="contextMenu-button" (click)="viewTechnique()">view technique</div>
             <div class="contextMenu-button" (click)="viewTactic()">view tactic</div>
+            <div class="contextMenu-button" *ngIf="techniqueVM.ruleURL" (click)="openRule()">view rule</div>
         </div>
         <div class="contextMenu-section" *ngIf="configService.contextMenuItems.length > 0">
             <div

--- a/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.spec.ts
+++ b/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.spec.ts
@@ -169,13 +169,13 @@ describe('ContextmenuComponent', () => {
 			expect(component.closeContextmenu).toHaveBeenCalled();
 		});
 
-		it('should open link URL and close context menu', () => {
-			const mockLink = { url: 'https://link-url.com' } as Link;
-			component.openLink(mockLink);
-			expect(window.open).toHaveBeenCalledWith(mockLink.url);
-			expect(component.closeContextmenu).toHaveBeenCalled();
-		});
-	});
+                it('should open rule URL in new tab when present', () => {
+                        const mockLink = { url: 'https://link-url.com', ruleURL: 'https://rule.com' } as Link;
+                        component.openLink(mockLink);
+                        expect(window.open).toHaveBeenCalledWith(mockLink.ruleURL, '_blank');
+                        expect(component.closeContextmenu).toHaveBeenCalled();
+                });
+        });
 
 	describe('pinCell', () => {
 		it('should toggle pinnedCell and close context menu', () => {

--- a/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.ts
+++ b/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.ts
@@ -115,7 +115,13 @@ export class ContextmenuComponent extends CellPopover implements OnInit {
     }
 
     public openLink(link: Link) {
-        window.open(link.url);
+        if (link.ruleURL) window.open(link.ruleURL, '_blank');
+        else window.open(link.url);
+        this.closeContextmenu();
+    }
+
+    public openRule() {
+        if (this.techniqueVM.ruleURL) window.open(this.techniqueVM.ruleURL, '_blank');
         this.closeContextmenu();
     }
 }

--- a/nav-app/src/app/matrix/technique-cell/tooltip/tooltip.component.html
+++ b/nav-app/src/app/matrix/technique-cell/tooltip/tooltip.component.html
@@ -23,6 +23,10 @@
             <td>Comment:</td>
             <td>{{ techniqueVM.comment }}</td>
         </tr>
+        <tr *ngIf="techniqueVM.ruleURL">
+            <td>Rule:</td>
+            <td><a [href]="techniqueVM.ruleURL" target="_blank">open</a></td>
+        </tr>
         <tr *ngFor="let note of notes">
             <td *ngIf="note.abstract" class="wrap">{{ note.abstract }}:</td>
             <td class="wrap" [attr.colspan]="note.abstract ? '1' : '2'">{{ note.content }}</td>


### PR DESCRIPTION
## Summary
- document optional `ruleURL` on technique objects
- support `ruleURL` in Link and TechniqueVM classes
- show rule information in tooltips and context menu
- underline techniques with rules and open rules in new tab

## Testing
- `npm test --prefix nav-app` *(fails: Chrome sandbox restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856dbc6b3d483248d693e37abb7e37d