### PR TITLE
Add service and CLI tests

### DIFF
--- a/nav-app/karma.conf.js
+++ b/nav-app/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
-        browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessCI'],
+        browsers: ['ChromeHeadlessCI'],
         customLaunchers: {
             ChromeHeadlessCI: {
                 base: 'ChromeHeadless',

--- a/nav-app/package.json
+++ b/nav-app/package.json
@@ -11,7 +11,8 @@
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0",
     "build": "ng build",
-    "test": "ng test",
+    "test": "npm run test:cli && ng test --watch=false --browsers=ChromeHeadlessCI",
+    "test:cli": "node ./node_modules/ts-node/dist/bin.js ../utils/generate-layer.spec.ts",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },

--- a/nav-app/src/app/services/framework-loader.service.spec.ts
+++ b/nav-app/src/app/services/framework-loader.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+import { DataService } from './data.service';
+import { ConfigService } from './config.service';
+import * as MockData from '../../tests/utils/mock-data';
+
+/** Tests verifying custom framework loading via DataService */
+describe('Custom Framework Loading', () => {
+    let configService: ConfigService;
+    let http: HttpClient;
+    let dataService: DataService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [DataService]
+        });
+        configService = TestBed.inject(ConfigService);
+        http = TestBed.inject(HttpClient);
+    });
+
+    it('should load techniques from custom framework', async () => {
+        configService.frameworks = [
+            {
+                name: MockData.simpleFramework.name,
+                identifier: 'custom',
+                version: MockData.simpleFramework.version,
+                file: 'assets/custom-framework.json'
+            }
+        ];
+        configService.versions = { enabled: false, entries: [] } as any;
+        spyOn(http, 'get').and.returnValue(of(MockData.simpleFramework));
+
+        dataService = new DataService(http, configService);
+        const domain = dataService.domains[0];
+        expect(domain.isCustom).toBeTrue();
+        await dataService.loadDomainData(domain.id, false);
+        expect(domain.techniques.length).toEqual(1);
+        expect(domain.tactics.length).toEqual(1);
+    });
+});

--- a/nav-app/src/app/services/sigma-rules.service.spec.ts
+++ b/nav-app/src/app/services/sigma-rules.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+import { SigmaRulesService, SigmaRule } from './sigma-rules.service';
+import { ConfigService } from './config.service';
+import { TechniqueVM } from '../classes';
+
+/** Tests for Sigma rule recommendation service */
+describe('SigmaRulesService', () => {
+    let service: SigmaRulesService;
+    let config: ConfigService;
+    let http: HttpClient;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [SigmaRulesService]
+        });
+        service = TestBed.inject(SigmaRulesService);
+        config = TestBed.inject(ConfigService);
+        http = TestBed.inject(HttpClient);
+    });
+
+    it('should load rules from YAML', async () => {
+        config.sigmaRulePaths = ['assets/sigma/example.yml'];
+        const yaml = `id: example-rule\ntitle: Example\ntags:\n  - attack.t0000`;
+        spyOn(http, 'get').and.returnValue(of(yaml));
+        await service.loadRules();
+        expect(service.rules.length).toBe(1);
+        expect(service.rules[0].title).toBe('Example');
+        expect(service.rules[0].path).toBe('assets/sigma/example.yml');
+    });
+
+    it('should recommend rules for unannotated technique', () => {
+        service.rules = [{ title: 'r', tags: ['T0000'], path: 'p' }];
+        const tvm = new TechniqueVM('T0000^tactic');
+        const vm: any = {
+            techniqueVMs: new Map([[tvm.technique_tactic_union_id, tvm]]),
+            dataService: { getTechnique: () => ({ attackID: 'T0000', platforms: ['windows'] }) },
+            domainVersionID: ''
+        };
+        const recs = service.getLayerRecommendations(vm);
+        expect(recs.get('T0000')?.length).toBe(1);
+    });
+});

--- a/utils/generate-layer.spec.ts
+++ b/utils/generate-layer.spec.ts
@@ -1,0 +1,25 @@
+import { execSync } from 'child_process';
+import { readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+// simple test for generate-layer.ts script using bundled sample data
+const script = resolve(__dirname, 'generate-layer.ts');
+const rules = resolve(__dirname, 'security-platform-export.csv');
+const framework = resolve(__dirname, 'temp-framework.json');
+const output = resolve(__dirname, 'test-layer.json');
+
+// minimal framework mapping tags to technique IDs
+writeFileSync(
+    framework,
+    JSON.stringify({ techniques: [{ id: 'T1059', tags: ['attack.T1059'] }] })
+);
+
+execSync(`npx ts-node ${script} --rules ${rules} --framework ${framework} --output ${output}`, { stdio: 'inherit' });
+const layer = JSON.parse(readFileSync(output, 'utf8'));
+unlinkSync(output);
+unlinkSync(framework);
+
+if (!layer.techniques || layer.techniques.length === 0) {
+    throw new Error('No techniques produced');
+}
+console.log('generate-layer spec passed');


### PR DESCRIPTION
## Summary
- add test for loading custom frameworks
- add sigma rule recommendation test
- create CLI test for generating Navigator layers
- run CLI test before Angular tests
- ensure Angular tests use headless Chrome

## Testing
- `npm --prefix nav-app test`

------
https://chatgpt.com/codex/tasks/task_e_6856f428a2fc83248e6d4a3873604a6f